### PR TITLE
feat/pdf file support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-markdown": "^10.1.0",
+        "react-pdftotext": "^1.3.4",
         "react-router-dom": "^6.26.2",
         "react-syntax-highlighter": "^15.6.1",
         "sonner": "^1.5.0",

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -17,13 +17,6 @@ export function ChatInput({ onSendMessage, onStopGenerating, isGenerating, disab
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
-    useEffect(() => {
-        if (textareaRef.current) {
-            textareaRef.current.style.height = 'auto';
-            textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`;
-        }
-    }, [input]);
-
     const handleSubmit = (e: FormEvent) => {
         e.preventDefault();
         if ((input.trim() || attachedFiles.length > 0) && !disabled) {
@@ -64,6 +57,19 @@ export function ChatInput({ onSendMessage, onStopGenerating, isGenerating, disab
     const removeAttachedFile = (index: number) => {
         setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
     };
+
+    useEffect(() => {
+        if (textareaRef.current) {
+            textareaRef.current.style.height = 'auto';
+            textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 200)}px`;
+        }
+    }, [input]);
+
+    useEffect(() => {
+        if (!isGenerating && textareaRef.current) {
+            textareaRef.current.focus();
+        }
+    }, [isGenerating]);
 
     return (
         <form onSubmit={handleSubmit} className="relative px-4 py-4 space-y-4 bg-transparent">

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -109,7 +109,7 @@ export function ChatInput({ onSendMessage, onStopGenerating, isGenerating, disab
                     value={input}
                     onChange={(e) => setInput(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    disabled={disabled}
+                    disabled={disabled || isGenerating}
                     rows={1}
                 />
 

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -12,7 +12,6 @@ interface ChatMessageProps {
 export function ChatMessage({ message }: ChatMessageProps) {
     const isUser = message.role === 'user';
     const isSystem = message.role === 'system';
-    const [copiedBlocks, setCopiedBlocks] = useState<Record<string, boolean>>({});
     const [showThinking, setShowThinking] = useState(false);
     const messageRef = useRef<HTMLDivElement>(null);
     const [attachedFiles, setAttachedFiles] = useState<string[]>([]);
@@ -42,7 +41,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
     const removeFileSections = (content: string): { cleanContent: string; extractedFiles: string[] } => {
         let result = content;
         const fileStartRegex = /<file name="[^"]*">/g;
-        let match;
+        let match: RegExpExecArray | null;
         const extractedFiles: string[] = [];
 
         while ((match = fileStartRegex.exec(result)) !== null) {
@@ -220,8 +219,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
 
         const codeBlocks = messageRef.current.querySelectorAll('pre code');
 
-        codeBlocks.forEach((codeBlock, index) => {
-            const id = `code-${message.id}-${index}`;
+        codeBlocks.forEach((codeBlock) => {
             const pre = codeBlock.parentElement;
 
             if (!pre || pre.querySelector('.copy-button')) return;

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -2,6 +2,19 @@ import { useCallback, useReducer, useState, useEffect } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { nanoid } from '@/lib/utils';
 
+const FILE_SYSTEM_PROMPT = `
+You can directly read PDF files, never claim to not be able to read them.
+You will directly read them by using the <file> tag.
+All the user provided file attachments are sent to the AI model through <file> tags.
+The file content is stored as a string in between the <file> and </file> tags.
+The AI model can access the file content and generate a response based on the file content.
+The AI model will also receive the associated file name as an attribute in the <file> tag.
+An example of a file tag is <file name="example.txt">This is the content of the file</file>.
+Never mention the <file> tag in your messages, as it is only used for file attachments.
+`;
+
+const PERSISTENT_SYSTEM_PROMPT = `${FILE_SYSTEM_PROMPT}`;
+
 export interface ChatMessage {
     id: string;
     role: 'user' | 'assistant' | 'system';
@@ -326,7 +339,12 @@ export function useChat(baseUrl: string = 'http://localhost:8000') {
                     .map(({ role, content }) => ({ role, content }));
 
                 if (currentSession.systemPrompt) {
-                    messages.unshift({ role: 'system', content: currentSession.systemPrompt });
+                    messages.unshift({
+                        role: 'system',
+                        content: `${PERSISTENT_SYSTEM_PROMPT}\n${currentSession.systemPrompt}`,
+                    });
+                } else {
+                    messages.unshift({ role: 'system', content: PERSISTENT_SYSTEM_PROMPT });
                 }
 
                 messages.push({ role: 'user', content });

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -279,7 +279,7 @@ export default function Chat() {
 
                 if (file.type === 'application/pdf') {
                     fileContent = await extractText(file);
-                } else if (file.type.startsWith('text/')) {
+                } else {
                     fileContent = await readFileContent(file);
                 }
 


### PR DESCRIPTION
Added support for reading content of PDF files.
Added custom system prompt for reading file content between <file> tags and added it to the LLM context.
Added input disabling and refocusing, if the LLM is generating content -- fixes being able to send multiple messages while the stream of the previous message is still generating.
